### PR TITLE
[RIP-14] Specify user for Pre- and Post start commands

### DIFF
--- a/riptide/config/document/service.py
+++ b/riptide/config/document/service.py
@@ -242,6 +242,17 @@ class Service(ContainerDefinitionYamlConfigDocument):
             Please note that, if you set this to false and also specify the role 'src', you may run
             into permission issues.
 
+        [run_pre_start_as_current_user]: 'auto' or bool
+            Whether to run pre start commands the user using riptide
+            or image default. Default is 'auto' which means the value of `run_as_current_user`
+            will be used.
+
+        [run_post_start_as_current_user]: 'auto' or bool
+            Whether to run post start commands the user using riptide
+            or image default. Default is 'auto' which means the value of `run_as_current_user`
+            will be used.
+
+
         [allow_full_memlock]: bool
             Whether to set memlock ulimit to -1:-1 (soft:hard).
             This is required for some database services, such as Elasticsearch.
@@ -320,6 +331,8 @@ class Service(ContainerDefinitionYamlConfigDocument):
                 # Limitation: If false and the image USER is not root,
                 #             then a user with the id of the image USER must exist in /etc/passwd of the image.
                 Optional('run_as_current_user'): bool,
+                Optional('run_pre_start_as_current_user'): Or('auto', bool),
+                Optional('run_post_start_as_current_user'): Or('auto', bool),
                 # DEPRECATED. Inverse of run_as_current_user if set
                 Optional('run_as_root'): bool,
                 # Whether to create the riptide user and group, mapped to current user. Default: False
@@ -364,6 +377,10 @@ class Service(ContainerDefinitionYamlConfigDocument):
             self.doc["run_as_current_user"] = not self.doc["run_as_root"]
         if "run_as_current_user" not in self:
             self.doc["run_as_current_user"] = True
+        if "run_pre_start_as_current_user" not in self or self.doc["run_pre_start_as_current_user"] == "auto":
+            self.doc["run_pre_start_as_current_user"] = self.doc["run_as_current_user"]
+        if "run_post_start_as_current_user" not in self or self.doc["run_post_start_as_current_user"] == "auto":
+            self.doc["run_post_start_as_current_user"] = self.doc["run_as_current_user"]
 
         if "dont_create_user" not in self:
             self.doc["dont_create_user"] = False

--- a/riptide/db/environments.py
+++ b/riptide/db/environments.py
@@ -33,7 +33,10 @@ class DbEnvironments:
         self.config = self._read_configuration()
         self.engine = engine
 
-        if project.parent()["performance"]["dont_sync_named_volumes_with_host"]:
+        if project.parent()["performance"]["dont_sync_named_volumes_with_host"] == "auto":
+            # TODO: This is obviously not ideal.
+            self.impl = DataDirectoryDbEnvImpl(self)
+        elif project.parent()["performance"]["dont_sync_named_volumes_with_host"]:
             self.impl = NamedVolumeDbEnvImpl(self)
         else:
             self.impl = DataDirectoryDbEnvImpl(self)

--- a/riptide/db/environments.py
+++ b/riptide/db/environments.py
@@ -33,10 +33,7 @@ class DbEnvironments:
         self.config = self._read_configuration()
         self.engine = engine
 
-        if project.parent()["performance"]["dont_sync_named_volumes_with_host"] == "auto":
-            # TODO: This is obviously not ideal.
-            self.impl = DataDirectoryDbEnvImpl(self)
-        elif project.parent()["performance"]["dont_sync_named_volumes_with_host"]:
+        if project.parent()["performance"]["dont_sync_named_volumes_with_host"]:
             self.impl = NamedVolumeDbEnvImpl(self)
         else:
             self.impl = DataDirectoryDbEnvImpl(self)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 from setuptools import setup, find_packages
 
 # README read-in


### PR DESCRIPTION
This implements specifying whether pre- and post start commands should be run as the current local user or the user configured in the Dockerfile.

Background:
By default all services are run as the local user. This doesn't work for things like Nginx or Apache, so `run_as_current_user` can be set to false, to run them as the user specified in the Docker image. This introduces permission issues, because the pre- and post start commands where previously also run as this user then. Now this can be configured, so that pre and post start commands can still be run as the local user.
To mitigate this in the past we used things like `chown` and `su` at the end of pre- and post start commands, this was a dirty hack. See the PR at our internal Riptide repository for info.

@Naftula70 @aptudock @hktudock
I can't add you as reviewers since you aren't collaborators of this repo, but can you still have a look? If I get no opposing comments I would merge this on Thursday.