### PR TITLE
[RIP-16] Env Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 idna==2.8
 schema==0.7.1
 pyyaml==5.1.2
-configcrunch>=0.3.3
+configcrunch==0.3.7
 appdirs==1.4.3
 janus==0.4.0
 psutil==5.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psutil==5.6.6
 GitPython==3.0.8
 pywinpty==0.5.5; sys_platform == 'win32'
 python-hosts==0.4.7
+python-dotenv==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 from setuptools import setup, find_packages
 
 # README read-in
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         # TEMPORARY, see #2:
         'idna <= 2.8',
-        'configcrunch >= 0.3.4',
+        'configcrunch >= 0.3.7',
         'schema >= 0.6',
         'pyyaml >= 5.1',
         'appdirs >= 1.4',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         'psutil >= 5.6',
         'GitPython >= 3.0',
         'pywinpty >= 0.5.5; sys_platform == "win32"',
-        'python-hosts >= 0.4'
+        'python-hosts >= 0.4',
+        'python-dotenv >= 0.19.0'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- Adds support for services and commands to read in `.env` files.
- Adds support for reading in `riptide.local.yml` files (if they exist).

This closes #8.