### PR TITLE
#14: Support multiple possible start commands for services

### DIFF
--- a/riptide/engine/abstract.py
+++ b/riptide/engine/abstract.py
@@ -25,7 +25,8 @@ class AbstractEngine(ABC):
     def start_project(self,
                       project: 'Project',
                       services: List[str],
-                      quick=False) -> MultiResultQueue[StartStopResultStep]:
+                      quick=False,
+                      command_group: str = "default") -> MultiResultQueue[StartStopResultStep]:
         """
         Starts all services in the project.
 
@@ -43,6 +44,7 @@ class AbstractEngine(ABC):
         :type project: 'Project'
         :param services: Names of the services to start
         :param quick: If True: Skip pre_start and post_start commands.
+        :param command_group: The command group of all services that should be used for the started containers.
 
         :return: MultiResultQueue[StartResult]
         """
@@ -157,7 +159,8 @@ class AbstractEngine(ABC):
     def service_fg(self,
                    project: 'Project',
                    service_name: str,
-                   arguments: List[str]
+                   arguments: List[str],
+                   command_group: str = "default"
     ) -> None:
         """
         Execute a service and attach output to stdout/stdin/stderr.
@@ -177,6 +180,7 @@ class AbstractEngine(ABC):
         :param project: 'Project'
         :param service_name: str
         :param arguments: List of arguments
+        :param command_group: The command group of all services that should be used for the fg service container
         :return:
         """
 

--- a/riptide/engine/results.py
+++ b/riptide/engine/results.py
@@ -29,7 +29,7 @@ class ResultError(EndResultQueue):
         self.cause = cause
         self.traceback_string = "Unknown reason."
         if cause:
-            self.traceback_string = "".join(traceback.format_exception(etype=type(cause), value=cause, tb=cause.__traceback__))
+            self.traceback_string = "".join(traceback.format_exception(type(cause), value=cause, tb=cause.__traceback__))
         super().__init__(*args, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
This adds support for specifying multiple commands for services and switching between them based on "groups" that can be specified during start.

Example config for a service:
```yaml
        command:
          default: 'yarn dev'
          inspect: 'yarn dev:inspect'
```

Running `riptide start -s inspect` will use the `inspect` group and run the second command. Not specifying the `-c` flag will run the `default` command. "Old" string based command specification is still possible (will be treated like default).

This will resolve #14.