### PR TITLE
[Service] Add option to define additional subdomains

### DIFF
--- a/riptide/config/document/service.py
+++ b/riptide/config/document/service.py
@@ -189,6 +189,9 @@ class Service(ContainerDefinitionYamlConfigDocument):
                     If true command containers will also recreate the file every time they are started.
                     Started services always recreate the processed file on start, regardless of this setting.
 
+        [additional_subdomains]: List[str]
+            List of additional subdomains that will be made available on the host system.
+
         [additional_ports]
             Additional TCP and/or UDP ports that will be made available on the host system.
             For details see section in
@@ -354,6 +357,7 @@ class Service(ContainerDefinitionYamlConfigDocument):
                 # Whether to create the riptide user and group, mapped to current user. Default: False
                 Optional('dont_create_user'): bool,
                 Optional('working_directory'): str,
+                Optional('additional_subdomains'): [str],
                 Optional('additional_ports'): {
                     str: {
                         'title': str,
@@ -419,6 +423,9 @@ class Service(ContainerDefinitionYamlConfigDocument):
 
         if "read_env_file" not in data:
             data["read_env_file"] = True
+
+        if "additional_subdomains" not in data:
+            data["additional_subdomains"] = []
 
         if "db" in data["roles"]:
             self._db_driver = db_driver_for_service.get(data, self)
@@ -728,3 +735,28 @@ class Service(ContainerDefinitionYamlConfigDocument):
         if "main" in self.internal_get("roles"):
             return self.get_project().internal_get("name") + "." + self.parent_doc.parent_doc.parent_doc.internal_get("proxy")["url"]
         return self.get_project().internal_get("name") + DOMAIN_PROJECT_SERVICE_SEP + self.internal_get("$name") + "." + self.parent_doc.parent_doc.parent_doc.internal_get("proxy")["url"]
+
+    @variable_helper
+    def additional_domains(self) -> [str]:
+        """
+        Returns the full domain names that this service should be available under in addition to the main domain.
+        These are the same domains as used for the proxy server.
+
+        Example usage::
+
+            something:
+              {{%- for additional_domain in dditional_domains() %}}
+              - {{ additional_domain }}
+              {{%- endfor %}}
+
+        Example result::
+
+            something:
+              - 'https://first.project--service.riptide.local'
+              - 'https://seccond.project--service.riptide.local'
+        """
+        if "main" in self.internal_get("roles"):
+            return [f'{subdomain}.{self.get_project().internal_get("name")}.{self.parent_doc.parent_doc.parent_doc.internal_get("proxy")["url"]}'
+                    for subdomain in self.internal_get("additional_subdomains")]
+        return [f'{subdomain}.{self.get_project().internal_get("name")}{DOMAIN_PROJECT_SERVICE_SEP}{self.internal_get("$name")}.{self.parent_doc.parent_doc.parent_doc.internal_get("proxy")["url"]}'
+                for subdomain in self.internal_get("additional_subdomains")]

--- a/riptide/config/hosts.py
+++ b/riptide/config/hosts.py
@@ -38,10 +38,12 @@ def update_hosts_file(system_config: Config, warning_callback=lambda msg: None):
                 for service in system_config["project"]["app"]["services"].values():
                     domain_list = [service.domain()]
                     if len(service.additional_domains()) > 0:
-                        domain_list.extend(service.additional_domains())
-                    if not hosts.exists(names=domain_list):
-                        changes = True
-                        new_entries.append(HostsEntry(entry_type='ipv4', address='127.0.0.1', names=domain_list))
+                        domain_list.extend(service.additional_domains().values())
+                    for domain in domain_list:
+                        # We need to do this one-by-one because otherwise exists returns True even if we add new domains.
+                        if not hosts.exists(names=[domain]):
+                            changes = True
+                            new_entries.append(HostsEntry(entry_type='ipv4', address='127.0.0.1', names=[domain]))
             hosts.add(new_entries)
             if changes:
                 try:

--- a/riptide/config/hosts.py
+++ b/riptide/config/hosts.py
@@ -36,10 +36,12 @@ def update_hosts_file(system_config: Config, warning_callback=lambda msg: None):
 
             if "services" in system_config["project"]["app"]:
                 for service in system_config["project"]["app"]["services"].values():
-                    domain = service.domain()
-                    if not hosts.exists(names=[domain]):
+                    domain_list = [service.domain()]
+                    if len(service.additional_domains()) > 0:
+                        domain_list.extend(service.additional_domains())
+                    if not hosts.exists(names=domain_list):
                         changes = True
-                        new_entries.append(HostsEntry(entry_type='ipv4', address='127.0.0.1', names=[domain]))
+                        new_entries.append(HostsEntry(entry_type='ipv4', address='127.0.0.1', names=domain_list))
             hosts.add(new_entries)
             if changes:
                 try:

--- a/riptide/tests/unit/config/document/service_test.py
+++ b/riptide/tests/unit/config/document/service_test.py
@@ -722,8 +722,8 @@ class ServiceTestCase(unittest.TestCase):
 
         self.assertEqual('TEST-PROJECT--TEST-SERVICE.TEST-URL', service.domain())
         self.assertEqual(2, len(service.additional_domains()))
-        self.assertEqual('first.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[0])
-        self.assertEqual('second.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[1])
+        self.assertEqual('first.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()["first"])
+        self.assertEqual('second.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()["second"])
 
     def test_additional_domains_main(self):
         system = YamlConfigDocumentStub.make({'proxy': {'url': 'TEST-URL'}})

--- a/riptide/tests/unit/config/document/service_test.py
+++ b/riptide/tests/unit/config/document/service_test.py
@@ -710,6 +710,36 @@ class ServiceTestCase(unittest.TestCase):
 
         self.assertEqual('TEST-PROJECT.TEST-URL', service.domain())
 
+    def test_additional_domains_not_main(self):
+        system = YamlConfigDocumentStub.make({'proxy': {'url': 'TEST-URL'}})
+        project = ProjectStub({'name': 'TEST-PROJECT'}, parent=system)
+        app = YamlConfigDocumentStub.make({}, parent=project)
+        service = module.Service.from_dict({
+            '$name': 'TEST-SERVICE',
+            'roles': ['?'],
+            'additional_subdomains': ['first', 'second']
+        }, parent=app)
+
+        self.assertEqual('TEST-PROJECT--TEST-SERVICE.TEST-URL', service.domain())
+        self.assertEqual(2, len(service.additional_domains()))
+        self.assertEqual('first.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[0])
+        self.assertEqual('second.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[1])
+
+    def test_additional_domains_main(self):
+        system = YamlConfigDocumentStub.make({'proxy': {'url': 'TEST-URL'}})
+        project = ProjectStub({'name': 'TEST-PROJECT'}, parent=system)
+        app = YamlConfigDocumentStub.make({}, parent=project)
+        service = module.Service.from_dict({
+            '$name': 'TEST-SERVICE',
+            'roles': ['main'],
+            'additional_subdomains': ['first', 'second']
+        }, parent=app)
+
+        self.assertEqual('TEST-PROJECT--TEST-SERVICE.TEST-URL', service.domain())
+        self.assertEqual(2, len(service.additional_domains()))
+        self.assertEqual('first.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[0])
+        self.assertEqual('second.TEST-PROJECT--TEST-SERVICE.TEST-URL', service.additional_domains()[1])
+
     @mock.patch("riptide.config.document.common_service_command.getuid", return_value=1234)
     def test_os_user(self, getuid_mock: Mock):
         service = module.Service.from_dict({})

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ commands =
     --ignore=riptide/tests/unit
 deps =
   -e .
-  -Urrequirements.txt
-  -Urrequirements_extra_riptide_from_git.txt
+  -r requirements.txt
+  -r requirements_extra_riptide_from_git.txt
   pytest >= 6


### PR DESCRIPTION
This PR adds a new option `additional_subdomains` and a new variable_helper `additional_domains` to Service objects.

- `additional_subdomains`: Allows you to configure one or more subdomains that should be made available on the host system when starting the service.
- `additional_domains`: Returns a dictionary of `{subdomain: full_domain}` mappings which can be used in configuration files for more customization with different subdomains.

Additionally I added some tests and fixed the `tox.ini`, but the unit tests still seem to be broken and I couldn't find an easy way to fix them, so I'm not sure if the tests I added are correct (although the code looks that way to me).

 