### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/riptide/config/files.py
+++ b/riptide/config/files.py
@@ -5,9 +5,11 @@ Riptide uses.
 Also provides some utility file-related functions.
 """
 import os
-import pkg_resources
+import atexit
+import importlib.resources
 import re
 from appdirs import user_config_dir
+from contextlib import ExitStack
 
 # Expected name of the project files during auto-discovery
 from typing import Optional
@@ -52,7 +54,11 @@ def discover_project_file() -> Optional[str]:
 
 def riptide_assets_dir() -> str:
     """ Path to the assets directory of riptide_lib. """
-    return pkg_resources.resource_filename('riptide', 'assets')
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files('riptide') / 'assets'
+    path = file_manager.enter_context(importlib.resources.as_file(ref))
+    return path
 
 
 def riptide_main_config_file() -> str:

--- a/riptide/db/driver/db_driver_for_service.py
+++ b/riptide/db/driver/db_driver_for_service.py
@@ -1,7 +1,7 @@
 """Module to resolve database drivers for services"""
 from typing import Union, TYPE_CHECKING, Optional
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 from riptide.db.driver.abstract import AbstractDbDriver
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ def get(service_data: Union['Service', dict], service: Optional['Service'] = Non
         service = service_data
     drivers = {
         entry_point.name:
-            entry_point.load() for entry_point in pkg_resources.iter_entry_points(DB_DRIVER_ENTRYPOINT_KEY)
+            entry_point.load() for entry_point in entry_points(group=DB_DRIVER_ENTRYPOINT_KEY)
     }
 
     if service_data["driver"]["name"] in drivers:

--- a/riptide/engine/loader.py
+++ b/riptide/engine/loader.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import entry_points
 
 from riptide.plugin.loader import load_plugins
 
@@ -10,7 +10,7 @@ def load_engine(engine_name):
     # Look up package entrypoints for engines
     engines = {
         entry_point.name:
-            entry_point.load() for entry_point in pkg_resources.iter_entry_points(ENGINE_ENTRYPOINT_KEY)
+            entry_point.load() for entry_point in entry_points(group=ENGINE_ENTRYPOINT_KEY)
     }
     if engine_name in engines:
         instance = engines[engine_name]()

--- a/riptide/plugin/loader.py
+++ b/riptide/plugin/loader.py
@@ -1,6 +1,6 @@
 from typing import Dict, Union, TYPE_CHECKING
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 from riptide.engine.abstract import AbstractEngine
 from riptide.plugin.abstract import AbstractPlugin
@@ -24,7 +24,7 @@ def load_plugins() -> Dict[str, AbstractPlugin]:
         # Look up package entrypoints for engines
         plugins = {
             entry_point.name:
-                entry_point.load()() for entry_point in pkg_resources.iter_entry_points(PLUGIN_ENTRYPOINT_KEY)
+                entry_point.load()() for entry_point in entry_points(group=PLUGIN_ENTRYPOINT_KEY)
         }
         for name, plugin in plugins.items():
             if not isinstance(plugin, AbstractPlugin):

--- a/riptide/tests/integration/engine/engine_loader.py
+++ b/riptide/tests/integration/engine/engine_loader.py
@@ -1,6 +1,6 @@
 from typing import Generator, Tuple
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 from riptide.engine.abstract import AbstractEngine
 from riptide.engine.loader import ENGINE_ENTRYPOINT_KEY
@@ -15,11 +15,11 @@ def load_engines() -> Generator[Tuple[str, AbstractEngine, AbstractEngineTester]
     # Collect testers
     engine_testers = {
         entry_point.name:
-            entry_point.load() for entry_point in pkg_resources.iter_entry_points(ENGINE_TESTER_ENTRYPOINT_KEY)
+            entry_point.load() for entry_point in entry_points(group=ENGINE_TESTER_ENTRYPOINT_KEY)
     }
 
     # Iterate engines
-    for engine_entry_point in pkg_resources.iter_entry_points(ENGINE_ENTRYPOINT_KEY):
+    for engine_entry_point in entry_points(group=ENGINE_ENTRYPOINT_KEY):
         if engine_entry_point.name not in engine_testers:
             print(f"WARNING: No engine tester found for {engine_entry_point.name}. Was not tested.")
             continue

--- a/riptide/tests/unit/util.py
+++ b/riptide/tests/unit/util.py
@@ -29,12 +29,12 @@ class UtilTestCase(unittest.TestCase):
         ]
         i = 0
         for version, expected in versions:
-            with mock.patch('pkg_resources.get_distribution') as gd_mock:
+            with mock.patch('importlib.metadata.version') as gd_mock:
                 version_mock = Mock()
                 version_mock.version = version
                 gd_mock.return_value = version_mock
 
                 self.assertEqual(expected, get_riptide_version(), f'for entry {i:d}')
 
-                gd_mock.assert_called_with('riptide_lib')
+                gd_mock.assert_called_with('riptide-lib')
             i += 1

--- a/riptide/util.py
+++ b/riptide/util.py
@@ -1,5 +1,5 @@
 """Various utility functions"""
-import pkg_resources
+from importlib.metadata import version
 
 
 class SystemFlag:
@@ -34,4 +34,4 @@ def get_riptide_version():
 
 
 def get_riptide_version_raw():
-    return pkg_resources.get_distribution("riptide_lib").version
+    return version("riptide-lib")


### PR DESCRIPTION
Since `pkg_resources` has been deprecated in favor of `importlib` this PR replaces the old API with the new one.

As a reference the following migration guides were used:
- [importlib.metadata](https://importlib-metadata.readthedocs.io/en/latest/migration.html)
- [importlib.resources](https://importlib-resources.readthedocs.io/en/latest/migration.html)