### PR TITLE
add ignore_original_entrypoint flag for normal commands

### DIFF
--- a/riptide/config/document/command.py
+++ b/riptide/config/document/command.py
@@ -99,6 +99,13 @@ class Command(ContainerDefinitionYamlConfigDocument):
             If enabled, the container uses network mode `host`. Overrides network and port settings
             Default: False
 
+        [ignore_original_entrypoint]: bool
+            If true, Riptide will not run the original entrypoint of the OCI image, but instead run the
+            command directly, as if no entrypoint was defined in the image.
+            Note that engines might ignore this setting, if they don't support it.
+
+            Default: False
+
         **Example Document:**
 
         .. code-block:: yaml
@@ -126,6 +133,7 @@ class Command(ContainerDefinitionYamlConfigDocument):
             Optional('config_from_roles'): [str],
             Optional('read_env_file'): bool,
             Optional('use_host_network'): bool,
+            Optional('ignore_original_entrypoint'): bool,
         })
 
     @classmethod


### PR DESCRIPTION
I ran into the issue that the `ignore_original_entrypoint` flag was not allowed for normal commands - only service commands - and riptide throws parsing errors.

Just enabling it for normal commands works fine. If no command for the riptide command is defined, riptide will probably just quickly run `bash -c ""` which does not throw errors. 