### PR TITLE
Support platform-specific additional volumes

### DIFF
--- a/riptide/config/document/command.py
+++ b/riptide/config/document/command.py
@@ -83,6 +83,10 @@ class Command(ContainerDefinitionYamlConfigDocument):
                     volume_name have the same content, even across projects. As a constraint, the name of
                     two volumes should only be the same, if the host path specified is also the same, to ensure
                     the same behaviour regardless of if the performance setting is enabled.
+                [host_system]: Or['Linux', 'Darwin', 'Windows']
+                    Only mount this volume if the host
+                    `system name <https://docs.python.org/3/library/platform.html#platform.system>` matches
+                    this value.
 
         [environment]
             Additional environment variables
@@ -130,6 +134,7 @@ class Command(ContainerDefinitionYamlConfigDocument):
                         Optional("mode"): str,  # default: rw - can be rw/ro.
                         Optional("type"): Or("directory", "file"),  # default: directory
                         Optional("volume_name"): str,
+                        Optional("host_system"): Or("Linux", "Darwin", "Windows"),
                     }
                 },
                 Optional("environment"): {str: str},

--- a/riptide/config/document/service.py
+++ b/riptide/config/document/service.py
@@ -239,6 +239,10 @@ class Service(ContainerDefinitionYamlConfigDocument):
                     volume_name have the same content, even across projects. As a constraint, the name of
                     two volumes should only be the same, if the host path specified is also the same, to ensure
                     the same behaviour regardless of if the performance setting is enabled.
+                [host_system]: Or['Linux', 'Darwin', 'Windows']
+                    Only mount this volume if the host
+                    `system name <https://docs.python.org/3/library/platform.html#platform.system>` matches
+                    this value.
 
         [driver]
             The database driver configuration, set this only if the role "db" is set.
@@ -382,6 +386,7 @@ class Service(ContainerDefinitionYamlConfigDocument):
                         Optional("mode"): Or("rw", "ro"),  # default: rw - can be rw/ro.
                         Optional("type"): Or("directory", "file"),  # default: directory
                         Optional("volume_name"): str,
+                        Optional("host_system"): Or("Linux", "Darwin", "Windows"),
                     }
                 },
                 Optional("allow_full_memlock"): bool,

--- a/riptide/config/service/volumes.py
+++ b/riptide/config/service/volumes.py
@@ -1,5 +1,6 @@
 """Logic to process additional volumes data and other volume related functions"""
 
+import platform
 from collections import OrderedDict
 
 import os
@@ -20,6 +21,10 @@ def process_additional_volumes(volumes: list[dict], project_folder: str):
     """
     out = OrderedDict()
     for vol in volumes:
+        # Skip volumes that are not marked for this platform (if host_system is defined as a filter)
+        if "host_system" in vol:
+            if vol["host_system"] != platform.system():
+                continue
         # ~ paths
         if vol["host"][0] == "~":
             vol["host"] = os.path.expanduser("~") + vol["host"][1:]


### PR DESCRIPTION
This adds support for platform specific volumes (cc @jeliebig, see https://github.com/theCapypara/riptide-repo/pull/50):

Example from that PR could be now written as:

```yml
additional_volumes:
  mac-why:
    host: "/private{{ get_tempdir() }}/ide-phpinfo.php"
    container: "/private{{ get_tempdir() }}/ide-phpinfo.php"
    host_system: Darwin
```